### PR TITLE
Move devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
-  },
-  "devDependencies": {
+    "zod-validation-error": "^3.4.0",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@types/connect-pg-simple": "^7.0.3",


### PR DESCRIPTION
Some dev dependencies like "vite" are actually used in production 